### PR TITLE
(Windows) Fix seg fault due to layout mismatch and 4-byte `u64`/`i64` typedefs

### DIFF
--- a/RGFW/RGFW.h
+++ b/RGFW/RGFW.h
@@ -165,8 +165,8 @@ extern "C" {
 		typedef signed short 	i16;
 		typedef unsigned int 	u32;
 		typedef signed int		i32;
-		typedef unsigned long	u64;
-		typedef signed long		i64;
+		typedef unsigned long long	u64;
+		typedef signed long long		i64;
 	#else
 		#include <stdint.h>
 

--- a/RGFW/RGFW_windows.odin
+++ b/RGFW/RGFW_windows.odin
@@ -6,8 +6,8 @@ window_src :: struct {
     hdc : winapi.HDC, /*!< source HDC */
     hOffset : u32, /*!< height offset for window */
     ctx : winapi.HGLRC, /*!< source graphics context */
-    bitmap : winapi.HBITMAP,
     hdcMem  : winapi.HDC,
+    bitmap : winapi.HBITMAP,
     maxSize : area, 
     minSize : area /* for setting max/min resize (RGFW_WINDOWS) */
 }

--- a/RGFW/RGFW_windows.odin
+++ b/RGFW/RGFW_windows.odin
@@ -7,7 +7,7 @@ window_src :: struct {
     hOffset : u32, /*!< height offset for window */
     ctx : winapi.HGLRC, /*!< source graphics context */
     bitmap : winapi.HBITMAP,
-    
+    hdcMem  : winapi.HDC,
     maxSize : area, 
     minSize : area /* for setting max/min resize (RGFW_WINDOWS) */
 }


### PR DESCRIPTION
This is to address #7, which I also ran into when trying out the example.

I believe I've found two contributing issues:

1. The Odin version of the C struct `RGFW_window_src` was missing the `hdcMem` field that is present when the library is built with the default defines.
2. The 8-byte integer typedefs in `RGFW.h`, `u64`/`i64`, were using 4-byte `long` rather than `long long` for MSVC builds.

Adding the `hdcMem` field and fixing the typedefs resolves the issue without any (immediately apparent) further problems. I would like to have been more thorough/confident here, but I have never used RGFW before and lack the necessary familiarity.

I recognise that the RGFW bundled with the bindings is not a recent version, and minor tweaks for outdated bindings may not be all that meaningful, but I'm hoping this will at least avoid a crash for Windows users.